### PR TITLE
Allow opt-in to define root-extension separator.

### DIFF
--- a/autoload/counterpoint.vim
+++ b/autoload/counterpoint.vim
@@ -36,7 +36,7 @@ function! <SID>IsCounterpartExcluded (counterpart)
 endfunction
 
 function! <SID>GetRoot (file)
-  let parts = split(a:file, "[.]")
+  let parts = split(a:file, g:counterpoint_separator_pattern)
   if g:counterpoint_depth <= 0
     let root = parts[0]
   else
@@ -111,7 +111,7 @@ function! counterpoint#GetCounterparts ()
   call add(paths, ".")
   let paths = <SID>PrepareSearchPaths(paths, expand("%:h"))
 
-  let counterparts = globpath(join(paths, ","), root . ".*", 0, 1)
+  let counterparts = globpath(join(paths, ","), root . g:counterpoint_separator_pattern . "*", 0, 1)
 
   " Include listed buffers that match the root pattern.
   let buffers = []

--- a/doc/counterpoint.txt
+++ b/doc/counterpoint.txt
@@ -13,7 +13,7 @@ Counterpoint understands that. However, Counterpoint will also treat
 "a.osx.cpp" and "a.win.cpp" as members of the same collection of alternates.
 
 Specifically, Counterpart navigates between a group a files defined by a root
-name, which is everything to left of the first dot in a file name. A leading
+name, which is everything to left of the first separator in a file name. A leading
 dot (as exists in the names of invisible files) is still considered part of
 the root name. Anything after the root name is considered an extension, and
 Counterpoint will cycle between those extensions in alphabetical order.
@@ -98,13 +98,32 @@ as if `magic` was set and `cpoptions` as empty (see |expr-=~|).
 
 The default value is an empty array.
 
+|g:counterpoint_separator_pattern|          *g:counterpoint_separator_pattern*
+
+A regular expression where to split the current filename into root and
+extension elements. For example, to include files like `foo_p.h` that use
+both underscore ("_") and dot (".") in extension: >
+
+    let g:counterpoint_separator_pattern = "[._]"
+
+In this case the following files will be recognized as counterparts: >
+
+    foo.h
+    foo_p.h
+    foo_qnx.cpp
+    foo_qnx_p.h
+    foo_win.cpp
+<
+The default value is "[.]". See |wildcards| for the use of special characters.
+
 |g:counterpoint_depth|                      *g:counterpoint_depth*
 
 An integer that controls which portions of a filename Counterpoint considers
 the root name.
 
 To assemble a counterpart set, Counterpoint will split the current filename
-at dots (except for a leading dot, if present). Some portion of the resulting
+at separator (except for a leading dot, if present) defined by
+|g:counterpoint_separator_pattern|. Some portion of the resulting
 array elements will be considered the root name, and the rest will be
 considered the extension (the varying part of the counterparts). A value of 0
 for |g:counterpoint_depth| tells Counterpoint to behave "normally," that is

--- a/plugin/counterpoint.vim
+++ b/plugin/counterpoint.vim
@@ -32,5 +32,9 @@ if !exists("g:counterpoint_include_path")
   let g:counterpoint_include_path = 0
 endif
 
+if !exists("g:counterpoint_separator_pattern")
+  let g:counterpoint_separator_pattern = "[.]"
+endif
+
 command! -bang -nargs=* CounterpointNext :call counterpoint#CycleCounterpart(1, "<bang>", "<args>")
 command! -bang -nargs=* CounterpointPrevious :call counterpoint#CycleCounterpart(-1, "<bang>", "<args>")


### PR DESCRIPTION
This PR would allow to include files with underscode suffixes (typical in Qt development):

```
qfiledialog.cpp
qfiledialog.h
qfiledialog_p.h
```
